### PR TITLE
fix length error on course id while authorizenet payment

### DIFF
--- a/ecommerce/extensions/payment/processors/authorizenet.py
+++ b/ecommerce/extensions/payment/processors/authorizenet.py
@@ -100,9 +100,8 @@ class AuthorizeNet(BaseClientSidePaymentProcessor):
         line_items_list = apicontractsv1.ArrayOfLineItem()
         for line in basket.all_lines():
             line_item = apicontractsv1.lineItemType()
-            line_item.itemId = line.product.course_id
-            line_item.name = line.product.course_id
-            line_item.description = line.product.title
+            line_item.itemId = line_item.name = "{}_{}".format(basket.order_number, line.product.id)
+            line_item.description = line.product.course_id
             line_item.quantity = line.quantity
             line_item.unitPrice = line.line_price_incl_tax_incl_discounts / line.quantity
             line_items_list.lineItem.append(line_item)

--- a/ecommerce/extensions/payment/tests/processors/test_authorizenet.py
+++ b/ecommerce/extensions/payment/tests/processors/test_authorizenet.py
@@ -91,13 +91,14 @@ class AuthorizeNetTests(PaymentProcessorTestCaseMixin, TestCase):
         """
         expected_line_item = self.basket.all_lines()[0]
         expected_line_item_unit_price = expected_line_item.line_price_incl_tax_incl_discounts / expected_line_item.quantity
+        expected_custom_line_id = "{}_{}".format(self.basket.order_number, expected_line_item.product.id)
 
         actual_line_items_list = self.processor._get_authorizenet_lineitems(self.basket)
         actual_line_item = actual_line_items_list.lineItem[0]
 
-        self.assertEqual(actual_line_item.itemId, expected_line_item.product.course_id)
-        self.assertEqual(actual_line_item.name, expected_line_item.product.course_id)
-        self.assertEqual(actual_line_item.description, expected_line_item.product.title)
+        self.assertEqual(actual_line_item.itemId, expected_custom_line_id)
+        self.assertEqual(actual_line_item.name, expected_custom_line_id)
+        self.assertEqual(actual_line_item.description, expected_line_item.product.course_id)
         self.assertEqual(actual_line_item.quantity, expected_line_item.quantity)
         self.assertEqual(actual_line_item.unitPrice, expected_line_item_unit_price)
 


### PR DESCRIPTION
**Ticket link:** https://edlyio.atlassian.net/secure/RapidBoard.jspa?rapidView=3&modal=detail&selectedIssue=EDS-136

**Description:** 

**Error:**
Initially, we were using course_id as line_item_id for authorizenet payment. There is a constraint of 65 characters length on course_id at LMS side while line_item_id at the authorizenet side has a limitation of max 31 characters. 
So error occurs due to course_id of more than 31 characters as it violates the line_item_id constraint at the authorizenet side.

**Solution:** 
Instead of or course_id I have created custom_id using the combination of order_number and product_id to make it unique.

**Note:** We can still use order_number from authorizenet transaction record to track orders at the open-edx ecommerce side.