### PR TITLE
custom code to send refund email to course purchaser

### DIFF
--- a/ecommerce/templates/customer/email_base.html
+++ b/ecommerce/templates/customer/email_base.html
@@ -175,12 +175,18 @@
                 <tr>
                     <td class="container-padding" bgcolor="#ffffff" style="padding-left: 30px; padding-right: 30px; font-size: 14px; line-height: 20px; font-family: Open Sans, sans-serif; color: #333; background-color: #ffffff; border-bottom: 1px solid #cccccc; border-radius: 5px;">
 
-                        <table border="0" cellpadding="0" cellspacing="0" class="columns-container">
+                        <table border="0" width="100%" cellpadding="0" cellspacing="0" class="columns-container">
                           <tr>
                             <td class="force-col" style="padding-right: 20px;" valign="middle">
 
                                 <!-- ### COLUMN 1 - COPYRIGHT AND ADDRESS ### -->
-                                <table border="0" cellspacing="0" cellpadding="0" width="250" align="left" class="col-2-edx">
+                                <table border="0" width="100%" cellspacing="0" cellpadding="0" width="250" align="left" class="col-2-edx">
+                                <tr align="left" valign="top" style="font-size: 10px; color: #767676; font-style: italic;">
+                                   <p>{% blocktrans %}UC San Diego’s LearnX is administered by the Teaching + Learning Commons and supported by Information Technology Services.{% endblocktrans %}</p>
+                                   <p>{% blocktrans %}For customer support and technology assistance contact the UC San Diego LearnX team: learnx@ucsd.edu {% endblocktrans %}</p>
+                                   <p>{% blocktrans %}For course purchase refund and billing inquiries (do not include credit card information) contact the UC San Diego IT Service Hub:  servicedesk@ucsd.edu{% endblocktrans %}</p>
+                                   <p>{% blocktrans %}For instructors who are interested in using LearnX, or developing fully online courses, contact the Digital Learning Hub: online@ucsd.edu {% endblocktrans %}</p>
+                                </tr>
                                 <tr>
                                     <td align="left" valign="top" style="font-size: 10px; color: #767676; font-style: italic;">
                                         <br>
@@ -209,4 +215,3 @@
 <img src="{{tracking_pixel}}"/>
 </body>
 </html>
-

--- a/ecommerce/templates/customer/emails/commtype_refund_body.html
+++ b/ecommerce/templates/customer/emails/commtype_refund_body.html
@@ -1,0 +1,32 @@
+{% extends 'customer/email_base.html' %}
+{% load i18n %}
+{% block body %}
+<!-- Message Body -->
+<tr>
+    <td class="container-padding" bgcolor="#ffffff" style="background-color: #ffffff; padding-left: 30px; padding-right: 30px; font-size: 13px; line-height: 20px; font-family: Open Sans, sans-serif; color: #333; border-radius: 5px;" align="left">
+        <br>
+        <!--message HTML content -->
+        <p>{% blocktrans %}Hi {{full_name}},{% endblocktrans %}</p>
+        <br>
+        <p>{% blocktrans with course_name=course_name order_number=order_number %}We have processed your refund request for {{course_name}}. The reimbursement will appear on your credit card under order number {{order_number}}. To view your order receipt, visit the following link:{% endblocktrans %}</p>
+        <p>{{order_url}}</p>
+        <br>
+        <p>{% blocktrans %}We are sorry to see you go. If you would like to explore other courses that are available on LearnX @ UC San Diego, please visit {{explore_courses_url}}{% endblocktrans %}</p>
+        <!--/message HTML content -->
+        <br><br>
+    </td>
+</tr>
+
+<tr>
+    <td class="footer-padding" style="padding-left: 30px; padding-right: 30px; font-size: 13px; line-height: 20px; font-family: Open Sans, sans-serif; color: #002D40; background-color: #f3f3f3;" align="left">
+        <!--footer content -->
+        <br>
+        <p>{% blocktrans with course_name=course_name platform_name=platform_name %}You are receiving this email because your refund has been processed of course {{course_name}} on {{platform_name}}.{% endblocktrans %}</p>
+        <br>
+        <!--/footer content -->
+    </td>
+</tr>
+<!--/100% wrapper-->
+<br>
+<!--/Message Body -->
+{% endblock body %}

--- a/ecommerce/templates/customer/emails/commtype_refund_body.txt
+++ b/ecommerce/templates/customer/emails/commtype_refund_body.txt
@@ -1,0 +1,11 @@
+{% load i18n %}
+{% trans "Receipt Confirmation for: " %}{{course_title}}
+
+{% blocktrans %}Hi {{full_name}},{% endblocktrans %}
+{% blocktrans with course_name=course_name order_number=order_number %}We have processed your refund request for {{course_name}}. The reimbursement will appear on your credit card under order number {{order_number}}. {% endblocktrans %}
+{% trans "To view your order receipt, visit the following link:" %}
+{{order_url}}
+
+{% blocktrans %}We are sorry to see you go. If you would like to explore other courses that are available on LearnX @ UC San Diego, please visit {{explore_courses_url}}.{% endblocktrans %}
+
+{% blocktrans with course_title=course_name platform_name=platform_name %}You are receiving this email because your refund has been processed for course {{course_name}} on {{platform_name}}{% endblocktrans %}

--- a/ecommerce/templates/customer/emails/commtype_refund_subject.txt
+++ b/ecommerce/templates/customer/emails/commtype_refund_subject.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% trans "Refund Approved" %}


### PR DESCRIPTION
**Ticket Link:** 
https://edlyio.atlassian.net/secure/RapidBoard.jspa?rapidView=3&modal=detail&selectedIssue=EDS-152&assignee=5b5f2693cd0f822d875303b3

The following ticket is also linked with it:
https://edlyio.atlassian.net/secure/RapidBoard.jspa?rapidView=3&modal=detail&selectedIssue=EDS-142&assignee=5b5f2693cd0f822d875303b3

**Description:** Instead of using Sailthru, write custom code to send refund email to purchaser.

**Requirements:**
if waffle switch `sailthru_enable` is active from ecommerce admin panel then run default edx-flow of sending refund email through Sailthru tasks else send email from ecommerce edx through our custom code. 