### PR TITLE
Send refund failure email from ecommerce instead of edx-platform

### DIFF
--- a/ecommerce/settings/production.py
+++ b/ecommerce/settings/production.py
@@ -101,3 +101,4 @@ ENTERPRISE_API_URL = urljoin(ENTERPRISE_SERVICE_URL, 'api/v1/')
 # Authorizenet payment processor set a cookie for dashboard to show pending course purchased dashoard
 # notification. This cookie domain will be used to set and delete that cookie.
 ECOMMERCE_COOKIE_DOMAIN = config_from_yaml.get('ECOMMERCE_COOKIE_DOMAIN')
+ECOMMERCE_SUPPORT_EMAIL = config_from_yaml.get('ECOMMERCE_SUPPORT_EMAIL')

--- a/ecommerce/templates/customer/emails/commtype_refund_failed_body.html
+++ b/ecommerce/templates/customer/emails/commtype_refund_failed_body.html
@@ -1,0 +1,31 @@
+{% extends 'customer/email_base.html' %}
+{% load i18n %}
+{% block body %}
+<!-- Message Body -->
+<tr>
+    <td class="container-padding" bgcolor="#ffffff" style="background-color: #ffffff; padding-left: 30px; padding-right: 30px; font-size: 13px; line-height: 20px; font-family: Open Sans, sans-serif; color: #333; border-radius: 5px;" align="left">
+        <br>
+        <!--message HTML content -->
+        <p>{% blocktrans %}A Refund request for learner <b>{{learner_name}}</b> against transaction <b>{{reference_number}}</b> is failed.{% endblocktrans %}</p>
+        <p>{% trans "Complete details are as follows." %}</p>
+        <br>
+
+        <p>{% blocktrans %}<b>Learner</b>{% endblocktrans %}</p>
+        <p>{% blocktrans %}Name: {{learner_name}}{% endblocktrans %}</p>
+        <p>{% blocktrans %}Email: {{learner_email}}{% endblocktrans %}</p>
+
+        <p>{% blocktrans %}<b>Order</b>{% endblocktrans %}</p>
+        <p>{% blocktrans %}Order Number: {{order_number}}{% endblocktrans %}</p>
+        <p>{% blocktrans %}Reference Transacion ID: {{reference_number}}{% endblocktrans %}</P>
+        <p>{% blocktrans %}Course ID: {{course_id}}{% endblocktrans %}</p>
+        <p>{% blocktrans %}Course Name: {{course_name}}{% endblocktrans %}</p>
+
+        <p>{% blocktrans %}<b>Error</b>{% endblocktrans %}</p>
+        <p>{% blocktrans %}Code: {{error_code}}{% endblocktrans %}</p>
+        <p>{% blocktrans %}Message: {{error_message}}{% endblocktrans %}</p>
+    </td>
+        <!--/message HTML content -->
+</tr>
+<!--/100% wrapper-->
+<!--/Message Body -->
+{% endblock body %}

--- a/ecommerce/templates/customer/emails/commtype_refund_failed_body.txt
+++ b/ecommerce/templates/customer/emails/commtype_refund_failed_body.txt
@@ -1,0 +1,17 @@
+{% load i18n %}
+{% blocktrans %}A Refund request for learner {{learner_name}} against transaction {{reference_number}} is failed.{% endblocktrans %}
+{% trans "Complete details are as follows." %}
+
+{% blocktrans %}Learner{% endblocktrans %}
+{% blocktrans %}Name: {{learner_name}}{% endblocktrans %}
+{% blocktrans %}Email: {{learner_email}}{% endblocktrans %}
+
+{% blocktrans %}Order{% endblocktrans %}
+{% blocktrans %}Order Number: {{order_number}}{% endblocktrans %}
+{% blocktrans %}Reference Transacion ID: {{reference_number}}{% endblocktrans %}
+{% blocktrans %}Course ID: {{course_id}}{% endblocktrans %}
+{% blocktrans %}Course Name: {{course_name}}{% endblocktrans %}
+
+{% blocktrans %}Error{% endblocktrans %}
+{% blocktrans %}Code: {{error_code}}{% endblocktrans %}
+{% blocktrans %}Message: {{error_message}}{% endblocktrans %}

--- a/ecommerce/templates/customer/emails/commtype_refund_failed_subject.txt
+++ b/ecommerce/templates/customer/emails/commtype_refund_failed_subject.txt
@@ -1,0 +1,2 @@
+{% load i18n %}
+{% trans "Refund Failed" %}


### PR DESCRIPTION
**Tikcet Link:** https://edlyio.atlassian.net/secure/RapidBoard.jspa?rapidView=3&projectKey=EDS&modal=detail&selectedIssue=EDS-169

**Description:** Send refund failure email from ecommerce instead of edx-platform to make it more descriptive.

**Requirement:** set ECOMMERCE_SUPPORT_EMAIL in ecommerce configuration file (/edx/etc/ecommerce.yml).

![image](https://user-images.githubusercontent.com/42185078/71472808-461d8800-27f6-11ea-89ba-97a714307aa6.png)
