### PR TITLE
Exclude expired coupons while filtering

### DIFF
--- a/ecommerce/ucsd_features/services/coupons.py
+++ b/ecommerce/ucsd_features/services/coupons.py
@@ -69,7 +69,7 @@ class CouponService:
                 logger.info(
                     'Vouchers limit for coupon: {} has been reached.'
                     ' Need to make more vouchers for the coupon'.format(coupon_product)
-                    )
+                )
         return all_available_vouchers
 
     def _get_available_vouchers_in_coupon(self, coupon):
@@ -82,7 +82,9 @@ class CouponService:
             )
 
             if unassigned_vouchers:
-                available_vouchers = [x for x in unassigned_vouchers if x.is_available_to_user()[0]]
+                available_vouchers = [
+                    x for x in unassigned_vouchers if x.is_available_to_user()[0] and x.is_active()
+                ]
                 all_vouchers.extend(available_vouchers)
 
         return all_vouchers


### PR DESCRIPTION
#### Story Link
https://edlyio.atlassian.net/browse/EDS-266

#### PR Description

To fix the issue in which while filtering available vouchers, the expired (for which "valid until" date has passed) are also filtered in. We need to exclude those vouchers.

#### Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Change

#### Checklist before merging:

- [x] Squased
- [ ] Reviewd
