### PR TITLE
FIX: add course in "coupons_limit_reached" email

### DIFF
--- a/ecommerce/ucsd_features/views.py
+++ b/ecommerce/ucsd_features/views.py
@@ -51,6 +51,7 @@ class AssignVoucherView(GenericAPIView):
                             ))
                 coupons_link = '{}{}'.format(settings.ECOMMERCE_URL_ROOT, reverse('coupons:app', args=['']))
                 is_email_sent = send_email_notification(support_email, 'COUPONS_LIMIT_REACHED', {
+                    'course_id': course_key,
                     'coupons_link': coupons_link
                 }, site)
 


### PR DESCRIPTION
### story link:
https://edlyio.atlassian.net/browse/EDE-285

### description
For "Coupons limit reached" email, `course_id` was not being sent in the context. This PR fixes that. 

### Related PR in edx-theme
https://github.com/ucsd-ets/edx-theme/pull/50