### PR TITLE
FIX: unicode decode error upon payment completion

### DIFF
--- a/ecommerce/extensions/payment/utils.py
+++ b/ecommerce/extensions/payment/utils.py
@@ -27,7 +27,10 @@ class LxmlObjectJsonEncoder(json.JSONEncoder):
         if isinstance(o, lxml.objectify.NumberElement) or isinstance(o, lxml.objectify.FloatElement):
             return float(o)
         if isinstance(o, lxml.objectify.ObjectifiedDataElement):
-            return str(o)
+            try:
+                return str(o)
+            except UnicodeEncodeError:
+                return unicode(o).encode('utf-8')
         if hasattr(o, '__dict__'):
             return o.__dict__
         return json.JSONEncoder.default(self, o)


### PR DESCRIPTION
### Story link:
https://edlyio.atlassian.net/browse/EDE-848

### Description:
If there are any non-ascii characters in authorizenet form, the e-commerce service throws an exception due to which the record is not updated on e-commerce site and student's enrollment status is not updated.

## How to reproduce
- Go to LMS https://online-dev.ucsd.edu/
- Enroll in any course with verified mode https://online-dev.ucsd.edu/courses/course-v1:DMC+DMC5+2020_T2/course/
- Upgrade to verified
- Fill all the details in the authorizenet form
- Put non-ascii characters in any text field (e.g. write `tallidsvägen` in address field)
- Submit the form
- The authorizenet page will display success message but course status will not be updated
- if we see the e-commerce logs. there will be an error trace like this
```
edx.devstack-ironwood.master.ecommerce | Traceback (most recent call last):
edx.devstack-ironwood.master.ecommerce |   File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/payment/views/authorizenet.py", line 228, in post
edx.devstack-ironwood.master.ecommerce |     self.handle_payment(transaction_details, basket)
edx.devstack-ironwood.master.ecommerce |   File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/checkout/mixins.py", line 66, in handle_payment
edx.devstack-ironwood.master.ecommerce |     handled_processor_response = self.payment_processor.handle_processor_response(response, basket=basket)
edx.devstack-ironwood.master.ecommerce |   File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/payment/processors/authorizenet.py", line 320, in handle_processor_response
edx.devstack-ironwood.master.ecommerce |     transaction_dict = LxmlObjectJsonEncoder().encode(transaction_response)
edx.devstack-ironwood.master.ecommerce |   File "/usr/lib/python2.7/json/encoder.py", line 207, in encode
edx.devstack-ironwood.master.ecommerce |     chunks = self.iterencode(o, _one_shot=True)
edx.devstack-ironwood.master.ecommerce |   File "/usr/lib/python2.7/json/encoder.py", line 270, in iterencode
edx.devstack-ironwood.master.ecommerce |     return _iterencode(o, 0)
edx.devstack-ironwood.master.ecommerce |   File "/edx/app/ecommerce/ecommerce/ecommerce/extensions/payment/utils.py", line 30, in default
edx.devstack-ironwood.master.ecommerce |     return str(o)
edx.devstack-ironwood.master.ecommerce | UnicodeEncodeError: 'ascii' codec can't encode characters in position 8-10: ordinal not in range(128)
```