### PR TITLE
fix bug postal code is not saved in billing address

### DIFF
--- a/ecommerce/extensions/payment/views/authorizenet.py
+++ b/ecommerce/extensions/payment/views/authorizenet.py
@@ -114,7 +114,8 @@ class AuthorizeNetNotificationView(EdxOrderPlacementMixin, APIView):
                 state=str(getattr(transaction_bill, 'state', '')),
                 country=Country.objects.get(
                     iso_3166_1_a2__iexact=transaction_bill.country
-                )
+                ),
+                postcode=str(getattr(transaction_bill, 'zip', ''))
             )
 
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
ticket link: https://edlyio.atlassian.net/browse/EDE-875
problem: during payment with authorize.net postal code/zip wasn't being stored in the billing address
fix: postal code/zip is being stored in the billing address